### PR TITLE
Refactor date

### DIFF
--- a/src/ApiBundle/Controller/DefaultController.php
+++ b/src/ApiBundle/Controller/DefaultController.php
@@ -78,9 +78,6 @@ class DefaultController extends FOSRestController
         $form->submit($request->request->all());
 
         if ($form->isValid()) {
-            $date = new \DateTime("now", new \DateTimeZone('UTC'));
-            $comment->setDate($date);
-
             $this->get('symfonyzero.comment.manager')->create($comment);
 
             return ['data' => $comment];
@@ -111,13 +108,10 @@ class DefaultController extends FOSRestController
             throw new NotFoundHttpException("Comment not found");
         }
 
-        $date = $comment->getDate();
-
         $form = $this->createForm(new CommentType(), $comment);
         $form->submit($request->request->all());
 
         if ($form->isValid()) {
-            $comment->setDate($date);
             $this->get('symfonyzero.comment.manager')->update($comment);
 
             return ['data' => $comment];

--- a/src/ApiBundle/Controller/UserController.php
+++ b/src/ApiBundle/Controller/UserController.php
@@ -53,8 +53,6 @@ class UserController extends FOSRestController
         $form->submit($request->request->all());
 
         if ($form->isValid()) {
-            $user->setRegistrationDate(new \DateTime("now", new \DateTimeZone("UCT")));
-
             $event = new FormEvent($form, $request);
             $dispatcher->dispatch(FOSUserEvents::REGISTRATION_SUCCESS, $event);
 

--- a/src/ApiBundle/DataFixtures/ORM/CommentFixtures.php
+++ b/src/ApiBundle/DataFixtures/ORM/CommentFixtures.php
@@ -33,7 +33,6 @@ class CommentFixtures implements FixtureInterface, ContainerAwareInterface
         for ($i = 0; $i < $numComments; $i++){
             $comment = new Comment();
             $comment->setComment("Comment #".$i);
-            $comment->setDate(new \DateTime('now'), new \DateTimeZone('UTC'));
 
             $comments[] = $comment;
         }

--- a/src/ApiBundle/Entity/Comment.php
+++ b/src/ApiBundle/Entity/Comment.php
@@ -46,7 +46,7 @@ class Comment {
 
     /**
      * @var \DateTime
-     * @Assert\DateTime(message="Incorrect date foramt")
+     * @Assert\DateTime(message="Incorrect date format")
      * @ORM\Column(name="date", type="datetime", nullable=false)
      */
     private $date;

--- a/src/ApiBundle/Entity/Comment.php
+++ b/src/ApiBundle/Entity/Comment.php
@@ -51,6 +51,11 @@ class Comment {
      */
     private $date;
 
+    public function __construct()
+    {
+        $this->date = new \DateTime('now', new \DateTimeZone('UTC'));
+    }
+
     /**
      * Get id
      *

--- a/src/ApiBundle/Form/CommentType.php
+++ b/src/ApiBundle/Form/CommentType.php
@@ -12,12 +12,7 @@ class CommentType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('comment', null, [])
-            ->add('date', DateTimeType::class, array(
-                'widget' => 'single_text',
-                'model_timezone' => 'UTC',
-            ))
-        ;
+            ->add('comment', null, []);
     }
 
     public function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
When you create a new comment, form needs a datetime field, but the controller set date to "now"  and ignore your date.
I propose create a construct in entity and set date automatically when create new objects.

